### PR TITLE
Fix potential crash with corrupt buttons

### DIFF
--- a/Heroes.Icons/Xml/HeroesDataXml.cs
+++ b/Heroes.Icons/Xml/HeroesDataXml.cs
@@ -384,7 +384,12 @@ namespace Heroes.Icons.Xml
                     if (!string.IsNullOrEmpty(parentLink))
                         ability.ParentLink = parentLink;
 
-                    hero.Abilities.Add($"{ability.ReferenceNameId}|{ability.ButtonName}", ability);
+                    string abilityKey = $"{ability.ReferenceNameId}|{ability.ButtonName}";
+
+                    if (!hero.Abilities.ContainsKey(abilityKey))
+                    {
+                        hero.Abilities.Add(abilityKey, ability);
+                    }
                 }
             }
         }


### PR DESCRIPTION
I don't know why, but lately I've been having occasional crashes with "key already added" as the exception. This _seems_ to fix it, but I don't know why it's happening to begin wtih.